### PR TITLE
Allow folders named docs/ to be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ node_modules
 .build
 .pt
 *.swp
-docs
 .DS_Store
 .nyc_output/
 *.csv


### PR DESCRIPTION
This change removes docs from `.gitignore` in `slic-starter`. It is no longer required to be ignored and prevents _real_ `docs` folders from being committed to Git.